### PR TITLE
Fix toast listener leak

### DIFF
--- a/src/hooks/use-toast.ts
+++ b/src/hooks/use-toast.ts
@@ -182,7 +182,7 @@ function useToast() {
         listeners.splice(index, 1)
       }
     }
-  }, [state])
+  }, [])
 
   return {
     ...state,


### PR DESCRIPTION
## Summary
- fix event listener cleanup in `use-toast`

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run typecheck` *(fails: cannot find module 'next')*


------
https://chatgpt.com/codex/tasks/task_e_683f8d34614c8327913b6eefcbf1ff20