### PR TITLE
Fix Next.js spelling

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Firebase Studio
 
-This is a NextJS starter in Firebase Studio.
+This is a Next.js starter in Firebase Studio.
 
 To get started, take a look at src/app/page.tsx.


### PR DESCRIPTION
## Summary
- update README to use Next.js spelling on line 3

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683f8f94121883278ad76fb05ba8f0d8