### PR TITLE
Fix pie chart NaN filtering

### DIFF
--- a/src/components/app/ChartView.tsx
+++ b/src/components/app/ChartView.tsx
@@ -101,10 +101,12 @@ export function ChartView({ data, config }: ChartViewProps) {
   }
 
   if (chartType === "pie") {
-    const pieData = data.map(item => ({
-      name: item[xAxis],
-      value: parseFloat(item[yAxes[0]]), // Assuming yAxes[0] is the value for pie
-    })).filter(item => !isNaN(item.value) && item.value > 0);
+    const pieData = data
+      .map(item => ({
+        name: item[xAxis],
+        value: parseFloat(item[yAxes[0]]), // use first y-axis value for pie slices
+      }))
+      .filter(item => !isNaN(item.value));
 
     return (
       <ResponsiveContainer width="100%" height={400}>


### PR DESCRIPTION
## Summary
- allow zero-valued slices in pie chart by only filtering out `NaN`

## Testing
- `npm run lint` *(fails: interactive prompt)*
- `npm run typecheck`

------
https://chatgpt.com/codex/tasks/task_e_683f8f9c3c988327876b7dac3a7bff96